### PR TITLE
Configure the task later

### DIFF
--- a/plugin/src/main/kotlin/tmg/gradle/plugin/gms/location/Extensions.kt
+++ b/plugin/src/main/kotlin/tmg/gradle/plugin/gms/location/Extensions.kt
@@ -8,6 +8,14 @@ import org.gradle.api.tasks.TaskCollection
 
 internal fun <T : Task> TaskCollection<T>.maybeNamed(name: String, action: Action<T>) {
     runCatching { named(name, action) }
+        .onFailure {
+            // Task was not ready yet, wait for it to be added.
+            whenTaskAdded {
+                if (it.name == name) {
+                    action.execute(it)
+                }
+            }
+        }
 }
 
 internal fun DependencyConstraintHandler.createStrictConstraint(forcing: Int, variantName: String): DependencyConstraint {

--- a/plugin/src/main/kotlin/tmg/gradle/plugin/gms/location/TmgLocationFixPlugin.kt
+++ b/plugin/src/main/kotlin/tmg/gradle/plugin/gms/location/TmgLocationFixPlugin.kt
@@ -41,15 +41,17 @@ public abstract class TmgLocationFixPlugin : Plugin<Project> {
                         variant.compileConfiguration.dependencyConstraints.add(constraint)
                     }
 
-                    // Add task actions for reporting
-                    val transformTask = "transform${variant.name.replaceFirstChar { it.uppercaseChar() }}ClassesWithAsm"
-                    // FIXME: task name might change
-                    project.tasks.maybeNamed(transformTask) {
-                        val variantCallsites = callsites.computeIfAbsent(variant.name) { mutableSetOf() }
+                    project.afterEvaluate {
+                        // Add task actions for reporting
+                        val transformTask = "transform${variant.name.replaceFirstChar { it.uppercaseChar() }}ClassesWithAsm"
+                        // FIXME: task name might change
+                        project.tasks.maybeNamed(transformTask) {
+                            val variantCallsites = callsites.computeIfAbsent(variant.name) { mutableSetOf() }
 
-                        it.doLast(ReportCallsitesAction(ext, variantCallsites))
-                        if (ext.strict.getOrElse(false) && ext.forceApi.isPresent) {
-                            it.doLast(StrictAction(ext, variantCallsites))
+                            it.doLast(ReportCallsitesAction(ext, variantCallsites))
+                            if (ext.strict.getOrElse(false) && ext.forceApi.isPresent) {
+                                it.doLast(StrictAction(ext, variantCallsites))
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
finalizeDsl{} happens before the tasks are created. Defer task configuration using afterEvaluate{}, and also add a fallback using whenTaskAdded{}.